### PR TITLE
Update 2016-06-16-macdeploy2016.md

### DIFF
--- a/_posts/2016-06-16-macdeploy2016.md
+++ b/_posts/2016-06-16-macdeploy2016.md
@@ -35,8 +35,8 @@ Slides can be downloaded [here](https://dl.dropboxusercontent.com/u/429559/MacDe
 
 #### Other items
 
-* [outset](http://apps.tempel.org/PrefsEditor/) - Joe Chilcote
+* [outset](https://github.com/chilcote/outset) - Joe Chilcote
 * [LoginScriptPlugin](https://github.com/MagerValp/LoginScriptPlugin) - Per Olofsson
 * [FoundationPlist Pyton module](https://github.com/munki/munki/blob/master/code/client/munkilib/FoundationPlist.py) - Greg Neagle
 * [plutil(1) manpage](https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man1/plutil.1.html)
-* [XY Problem](docs.macsysadmin.se/2015/video/Day2Session2.mp4)
+* [XY Problem](xyproblem.info)


### PR DESCRIPTION
fix hyperlink error for outset
fix hyperlink XY Problem

---

It's really sad that I have to read your blog at work via the raw markdown. https://macops.ca/ is blocked 😭 

However it does make catching hyperlink errors easier.